### PR TITLE
Fixed constant death messages which appeared on each attack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to **CreatureChat™** are documented in this file. The form
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to 
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Fixed constant death messages which appeared on each attack (for Minecraft 1.21.2+)
+
 ## [2.5.0] - 2025-07-07
 
 ### Added

--- a/src/vs/v1_21_2/main/java/com/owlmaddie/mixin/MixinLivingEntity.java
+++ b/src/vs/v1_21_2/main/java/com/owlmaddie/mixin/MixinLivingEntity.java
@@ -101,12 +101,10 @@ public class MixinLivingEntity {
     }
 
     @Inject(
-            method = "getDamageAfterArmorAbsorb(Lnet/minecraft/world/damagesource/DamageSource;F)F",
-            at     = @At("RETURN")
+            method = "die(Lnet/minecraft/world/damagesource/DamageSource;)V",
+            at = @At("HEAD")
     )
-    private void afterArmor(DamageSource source,
-                            float rawDamage,
-                            CallbackInfoReturnable<Float> cir) {
+    private void onDeath(DamageSource source, CallbackInfo ci) {
         LivingEntity entity = (LivingEntity) (Object) this;
         Level world = entity.level();
 


### PR DESCRIPTION
Happens on Minecraft 1.21.2+. This was a regression in our expanding support for more versions of Minecraft.