### PR TITLE
Validate all mixins (during build)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to **CreatureChat™** are documented in this file. The form
 
 ## Unreleased
 
+### Added
+- New mixin validation on build script (to validate all injection entry points)
+
 ### Fixed
 - Fixed constant death messages which appeared on each attack (for Minecraft 1.21.2+)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to **CreatureChat™** are documented in this file. The form
 
 ### Added
 - New mixin validation on build script (to validate all injection entry points)
+- Validation of mixin targets (on build script)
 
 ### Fixed
 - Fixed constant death messages which appeared on each attack (for Minecraft 1.21.2+)

--- a/build.gradle
+++ b/build.gradle
@@ -115,11 +115,9 @@ afterEvaluate {
 // ───────────────────────────────────────────────────────────────────────────
 
 repositories {
-	// Add repositories to retrieve artifacts from in here.
-	// You should only use this when depending on other mods because
-	// Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
-	// See https://docs.gradle.org/current/userguide/declaring_repositories.html
-	// for more information about repositories.
+	maven {
+			url "https://repo.spongepowered.org/repository/maven-public/"
+	}
 }
 
 loom {
@@ -143,6 +141,10 @@ dependencies {
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+
+	// Validate mixin targets at compile time
+	annotationProcessor "org.spongepowered:mixin:0.8.7:processor"
+	clientAnnotationProcessor "org.spongepowered:mixin:0.8.7:processor"
 
 	// Test module dependencies
 	testRuntimeOnly    'org.junit.jupiter:junit-jupiter-engine:5.8.1'

--- a/build.gradle
+++ b/build.gradle
@@ -170,6 +170,7 @@ processResources {
 
 tasks.withType(JavaCompile).configureEach {
 	it.options.release = 17
+	it.options.compilerArgs += ['-Werror']
 }
 
 tasks.named("jar") {

--- a/build.gradle
+++ b/build.gradle
@@ -115,9 +115,9 @@ afterEvaluate {
 // ───────────────────────────────────────────────────────────────────────────
 
 repositories {
-	maven {
-			url "https://repo.spongepowered.org/repository/maven-public/"
-	}
+   mavenCentral()
+   maven { url "https://maven.fabricmc.net/" }
+   maven { url "https://repo.spongepowered.org/repository/maven-public/" }
 }
 
 loom {

--- a/build.sh
+++ b/build.sh
@@ -64,6 +64,10 @@ EOD
 
   echo "Running mixin target validation"
   ./gradlew build -x test -x validateAccessWidener --build-cache --parallel
+  if ! compgen -G "build/classes/java/main/*refmap.json" > /dev/null; then
+    echo "Error: mixin refmap missing; target validation did not run" >&2
+    exit 1
+  fi
   find build/libs -name '*sources*.jar' -delete
   mv build/libs/creaturechat-*.jar .
 

--- a/build.sh
+++ b/build.sh
@@ -62,6 +62,7 @@ EOD
   sed -i "s/\"minecraft\": \".*\"/\"minecraft\": \"~$mc_version\"/" \
     src/main/resources/fabric.mod.json
 
+  echo "Running mixin target validation"
   ./gradlew build -x test -x validateAccessWidener --build-cache --parallel
   find build/libs -name '*sources*.jar' -delete
   mv build/libs/creaturechat-*.jar .

--- a/src/client/java/com/owlmaddie/mixin/client/EntityRendererMixin.java
+++ b/src/client/java/com/owlmaddie/mixin/client/EntityRendererMixin.java
@@ -20,7 +20,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class EntityRendererMixin<T extends Entity> {
 
     @Inject(
-            method = "renderNameTag(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/network/chat/Component;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V",
+            method = "renderNameTagX(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/network/chat/Component;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V",
             at = @At("HEAD"),
             cancellable = true
     )    private void cancelRenderLabel(T entity, Component text, PoseStack matrices, MultiBufferSource vertexConsumers, int light, CallbackInfo ci) {

--- a/src/client/java/com/owlmaddie/mixin/client/EntityRendererMixin.java
+++ b/src/client/java/com/owlmaddie/mixin/client/EntityRendererMixin.java
@@ -20,7 +20,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class EntityRendererMixin<T extends Entity> {
 
     @Inject(
-            method = "renderNameTagX(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/network/chat/Component;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V",
+            method = "renderNameTag(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/network/chat/Component;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V",
             at = @At("HEAD"),
             cancellable = true
     )    private void cancelRenderLabel(T entity, Component text, PoseStack matrices, MultiBufferSource vertexConsumers, int light, CallbackInfo ci) {


### PR DESCRIPTION
Prevent runtime crashes due to invalid mixin targets - fail loudly on our build server