### PR TITLE
Run datagen during every build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -201,6 +201,31 @@ java {
 
 sourceSets.main.resources.srcDir "src/main/generated"
 
+def generatedResources = file("src/main/generated")
+
+tasks.named("runDatagen") {
+    outputs.dir generatedResources
+    doFirst {
+        delete generatedResources
+    }
+}
+
+tasks.named("classes") {
+    finalizedBy "runDatagen"
+}
+
+tasks.named("build") {
+    dependsOn "runDatagen"
+}
+
+tasks.named("sourcesJar") {
+    dependsOn "runDatagen"
+}
+
+tasks.named("clean") {
+    delete generatedResources
+}
+
 jar {
 	from("LICENSE") {
 		rename { "${it}_${project.base.archivesName.get()}"}

--- a/build.sh
+++ b/build.sh
@@ -70,10 +70,7 @@ EOD
   sed -i "s/\"minecraft\": \".*\"/\"minecraft\": \"~$mc_version\"/" \
     src/main/resources/fabric.mod.json
 
-  echo "Running data generation"
-  ./gradlew runDatagen --build-cache --parallel
-
-  echo "Running mixin target validation"
+  echo "Running build (datagen + mixin target validation)"
   run_build
   if ! compgen -G "build/classes/java/main/*refmap.json" > /dev/null; then
     echo "Error: mixin refmap missing; target validation did not run" >&2


### PR DESCRIPTION
## Summary
- ensure Fabric datagen output is cleaned and regenerated
- run datagen automatically for builds and source jars
- trigger datagen after the `classes` task so IDE builds regenerate resources

## Testing
- `./gradlew runDatagen`
- `./gradlew clean classes`
- `./gradlew build` *(fails: BehaviorTests > initializationError FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_68a01c0d7d088330a6a10c7450d4d03d