### PR TITLE
Make Gradle restarts opt-in

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 variables:
   GRADLE_OPTS: "-Dorg.gradle.daemon=false"
   JAVA_HOME: "/home/jonathan/.jdks/openjdk-22.0.1"
+  ALLOW_GRADLE_RESTART: "1"
 
 cache:
   paths:

--- a/build.sh
+++ b/build.sh
@@ -3,12 +3,14 @@ set -euo pipefail
 
 ONLY_VERSION=${ONLY_VERSION:-}
 DRY_RUN=${DRY_RUN:-0}
+ALLOW_GRADLE_RESTART=${ALLOW_GRADLE_RESTART:-}
 
 # Allow “pattern→empty” instead of “pattern→itself”
 shopt -s nullglob
 
 run_build() {
   ./gradlew build -x test -x validateAccessWidener --build-cache --parallel </dev/null && return 0
+  [[ -n "$ALLOW_GRADLE_RESTART" ]] || return 1
   echo "Gradle failed; attempting to clear locks and retry..."
   ./gradlew --stop >/dev/null 2>&1 || true
   find .gradle ~/.gradle -type f -name '*.lock' -delete 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Restart Gradle only when `ALLOW_GRADLE_RESTART` is set
- Enable gradle restart in CI via new `ALLOW_GRADLE_RESTART` env var

## Testing
- `DRY_RUN=1 ./build.sh`
- `ALLOW_GRADLE_RESTART=1 DRY_RUN=1 ./build.sh`
- `./gradlew test --info` *(fails: There were failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d53028408330bb0228157617ac15