### PR TITLE
Improved Auto rate-limits for automatic LLM requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to **CreatureChat™** are documented in this file. The form
 - Expanded 'no response' messages
 - build.gradle now includes running Fabric datagen (for generating the JSON loot tables)
 - Increasing max auto-generated messages to 12 (up from 3)
+- Improved Auto rate-limits for automatic LLM requests (show item, inventory, attack)
 
 ### Fixed
 - Fixed constant death messages which appeared on each attack (for Minecraft 1.21.2+)

--- a/src/main/java/com/owlmaddie/chat/AutoMessageBucket.java
+++ b/src/main/java/com/owlmaddie/chat/AutoMessageBucket.java
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2025 owlmaddie LLC
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Assets CC-BY-NC-SA-4.0; CreatureChat™ trademark © owlmaddie LLC - unauthorized use prohibited
+package com.owlmaddie.chat;
+
+/**
+ * A simple token bucket for rate limiting automatic messages.
+ */
+public class AutoMessageBucket {
+    private static final int MAX_TOKENS_CAP = 1000;
+    private static final int MAX_COOLDOWN_SECONDS = 3600;
+
+    private final int maxTokens;
+    private final int cooldownSeconds;
+    private int tokens;
+    private long lastRefill;
+
+    public AutoMessageBucket(int maxTokens, int cooldownSeconds) {
+        this.maxTokens = Math.max(1, Math.min(maxTokens, MAX_TOKENS_CAP));
+        this.cooldownSeconds = Math.max(1, Math.min(cooldownSeconds, MAX_COOLDOWN_SECONDS));
+        this.tokens = this.maxTokens;
+        this.lastRefill = System.currentTimeMillis();
+    }
+
+    /**
+     * Refill tokens based on elapsed time.
+     */
+    public void refill() {
+        long now = System.currentTimeMillis();
+        long elapsed = now - lastRefill;
+        int refill = (int) (elapsed / (cooldownSeconds * 1000L));
+        if (refill > 0) {
+            tokens = Math.min(maxTokens, tokens + refill);
+            lastRefill += refill * cooldownSeconds * 1000L;
+        }
+    }
+
+    /**
+     * @return {@code true} if at least one token is available.
+     */
+    public boolean hasTokens() {
+        refill();
+        return tokens > 0;
+    }
+
+    /**
+     * Consume one token. Call only if {@link #hasTokens()} is {@code true}.
+     */
+    public void consume() {
+        if (tokens > 0) {
+            tokens--;
+        }
+    }
+
+    /**
+     * Reset to full capacity immediately.
+     */
+    public void reset() {
+        tokens = maxTokens;
+        lastRefill = System.currentTimeMillis();
+    }
+}
+

--- a/src/main/java/com/owlmaddie/chat/ChatDataManager.java
+++ b/src/main/java/com/owlmaddie/chat/ChatDataManager.java
@@ -5,8 +5,10 @@ package com.owlmaddie.chat;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import com.owlmaddie.commands.ConfigurationHandler;
 import com.owlmaddie.network.ServerPackets;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.storage.LevelResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,6 +18,7 @@ import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.UUID;
 
 /**
  * The {@code ChatDataManager} class manages chat data for all entities. This class also helps
@@ -30,7 +33,6 @@ public class ChatDataManager {
     public static int DISPLAY_NUM_LINES = 3;
     public static int MAX_CHAR_IN_USER_MESSAGE = 512;
     public static int TICKS_TO_DISPLAY_USER_MESSAGE = 70;
-    public static int MAX_AUTOGENERATE_RESPONSES = 12;
     private static final Gson GSON = new Gson();
 
     public enum ChatStatus {
@@ -47,15 +49,18 @@ public class ChatDataManager {
 
     // HashMap to associate unique entity IDs with their chat data
     public ConcurrentHashMap<String, EntityChatData> entityChatDataMap;
+    public ConcurrentHashMap<UUID, AutoMessageBucket> autoResponseBuckets;
 
     public void clearData() {
         // Clear the chat data for the previous session
         entityChatDataMap.clear();
+        autoResponseBuckets.clear();
     }
 
     private ChatDataManager(Boolean server_only) {
         // Constructor
         entityChatDataMap = new ConcurrentHashMap<>();
+        autoResponseBuckets = new ConcurrentHashMap<>();
 
         if (server_only) {
             // Generate initial quest
@@ -77,6 +82,41 @@ public class ChatDataManager {
     // Retrieve chat data for a specific entity, or create it if it doesn't exist
     public EntityChatData getOrCreateChatData(String entityId) {
         return entityChatDataMap.computeIfAbsent(entityId, k -> new EntityChatData(entityId));
+    }
+
+    private AutoMessageBucket getPlayerBucket(UUID playerId, ConfigurationHandler.Config config) {
+        return autoResponseBuckets.computeIfAbsent(playerId,
+                k -> new AutoMessageBucket(config.getMaxPlayerAutoResponses(), config.getPlayerAutoCooldownSeconds()));
+    }
+
+    private AutoMessageBucket getEntityBucket(EntityChatData chatData, ConfigurationHandler.Config config) {
+        if (chatData.autoBucket == null) {
+            chatData.autoBucket = new AutoMessageBucket(config.getMaxEntityAutoResponses(), config.getEntityAutoCooldownSeconds());
+        }
+        return chatData.autoBucket;
+    }
+
+    public boolean handleAutoResponse(EntityChatData chatData, ServerPlayer player, boolean isAuto, ConfigurationHandler.Config config) {
+        AutoMessageBucket entityBucket = getEntityBucket(chatData, config);
+        AutoMessageBucket playerBucket = getPlayerBucket(player.getUUID(), config);
+
+        if (!isAuto) {
+            playerBucket.reset();
+            return true;
+        }
+
+        if (!entityBucket.hasTokens()) {
+            LOGGER.info("Auto response skipped for entity {}: entity cooldown active", chatData.entityId);
+            return false;
+        }
+        if (!playerBucket.hasTokens()) {
+            LOGGER.info("Auto response skipped for player {}: player cooldown active", player.getName().getString());
+            return false;
+        }
+
+        entityBucket.consume();
+        playerBucket.consume();
+        return true;
     }
 
     // Update the UUID in the map (i.e. bucketed entity and then released, changes their UUID)

--- a/src/main/java/com/owlmaddie/chat/EntityChatData.java
+++ b/src/main/java/com/owlmaddie/chat/EntityChatData.java
@@ -61,6 +61,7 @@ public class EntityChatData {
     public List<ChatMessage> previousMessages;
     public Long born;
     public Long death;
+    public transient AutoMessageBucket autoBucket;
 
     @SerializedName("playerId")
     @Expose(serialize = false)
@@ -84,6 +85,7 @@ public class EntityChatData {
         this.auto_generated = 0;
         this.previousMessages = new ArrayList<>();
         this.born = System.currentTimeMillis();;
+        this.autoBucket = null;
 
         // Old, unused migrated properties
         this.legacyPlayerId = null;

--- a/src/main/java/com/owlmaddie/commands/ConfigurationHandler.java
+++ b/src/main/java/com/owlmaddie/commands/ConfigurationHandler.java
@@ -78,6 +78,10 @@ public class ConfigurationHandler {
         private List<String> whitelist = new ArrayList<>();
         private List<String> blacklist = new ArrayList<>();
         private String story = "";
+        private int maxPlayerAutoResponses = 12;
+        private int playerAutoCooldownSeconds = 6;
+        private int maxEntityAutoResponses = 1;
+        private int entityAutoCooldownSeconds = 4;
 
         // Getters and setters for existing fields
         public String getApiKey() { return apiKey; }
@@ -122,5 +126,17 @@ public class ConfigurationHandler {
         // Add getter and setter
         public boolean getChatBubbles() { return chatBubbles; }
         public void setChatBubbles(boolean chatBubblesEnabled) { this.chatBubbles = chatBubblesEnabled; }
+
+        public int getMaxPlayerAutoResponses() { return maxPlayerAutoResponses; }
+        public void setMaxPlayerAutoResponses(int maxPlayerAutoResponses) { this.maxPlayerAutoResponses = maxPlayerAutoResponses; }
+
+        public int getPlayerAutoCooldownSeconds() { return playerAutoCooldownSeconds; }
+        public void setPlayerAutoCooldownSeconds(int playerAutoCooldownSeconds) { this.playerAutoCooldownSeconds = playerAutoCooldownSeconds; }
+
+        public int getMaxEntityAutoResponses() { return maxEntityAutoResponses; }
+        public void setMaxEntityAutoResponses(int maxEntityAutoResponses) { this.maxEntityAutoResponses = maxEntityAutoResponses; }
+
+        public int getEntityAutoCooldownSeconds() { return entityAutoCooldownSeconds; }
+        public void setEntityAutoCooldownSeconds(int entityAutoCooldownSeconds) { this.entityAutoCooldownSeconds = entityAutoCooldownSeconds; }
     }
 }

--- a/src/main/java/com/owlmaddie/goals/LeadPlayerGoal.java
+++ b/src/main/java/com/owlmaddie/goals/LeadPlayerGoal.java
@@ -75,7 +75,7 @@ public class LeadPlayerGoal extends PlayerBaseGoal {
 
                 ChatDataManager chatDataManager = ChatDataManager.getServerInstance();
                 EntityChatData chatData = chatDataManager.getOrCreateChatData(this.entity.getStringUUID());
-                if (!chatData.characterSheet.isEmpty() && chatData.auto_generated < chatDataManager.MAX_AUTOGENERATE_RESPONSES) {
+                if (!chatData.characterSheet.isEmpty()) {
                     ServerPackets.generate_chat("N/A", chatData, (ServerPlayer) this.targetEntity, this.entity, arrivedMessage, true);
                 }
             });

--- a/src/main/java/com/owlmaddie/mixin/MixinLivingEntity.java
+++ b/src/main/java/com/owlmaddie/mixin/MixinLivingEntity.java
@@ -66,9 +66,7 @@ public class MixinLivingEntity {
             // We don't want to constantly generate messages during a prolonged, multi-damage event
             ServerPlayer player = (ServerPlayer) attacker;
             EntityChatData chatData = getChatData(thisEntity);
-            if (!chatData.characterSheet.isEmpty() && chatData.auto_generated < ChatDataManager.MAX_AUTOGENERATE_RESPONSES) {
-                // Only auto-generate a response to being attacked if chat data already exists
-                // and this is the first attack event.
+            if (!chatData.characterSheet.isEmpty()) {
                 ItemStack weapon = player.getMainHandItem();
                 String weaponName = weapon.isEmpty() ? "with fists" : "with " + weapon.getItem().toString();
 

--- a/src/main/java/com/owlmaddie/mixin/MixinMobEntity.java
+++ b/src/main/java/com/owlmaddie/mixin/MixinMobEntity.java
@@ -221,7 +221,7 @@ public class MixinMobEntity implements ChatInventory, HasCustomInventoryScreen {
                 String giveItemMessage = "<" + serverPlayer.getName().getString() +
                         action_verb + "you " + itemCount + " " + itemName + ">";
 
-                if (!entityData.characterSheet.isEmpty() && entityData.auto_generated < chatDataManager.MAX_AUTOGENERATE_RESPONSES) {
+                if (!entityData.characterSheet.isEmpty()) {
                     ServerPackets.generate_chat("N/A", entityData, serverPlayer, thisEntity, giveItemMessage, true);
                 }
 

--- a/src/main/java/com/owlmaddie/network/ServerPackets.java
+++ b/src/main/java/com/owlmaddie/network/ServerPackets.java
@@ -110,7 +110,7 @@ public class ServerPackets {
                 if (entity != null) {
                     EntityChatData chatData = ChatDataManager.getServerInstance().getOrCreateChatData(entity.getStringUUID());
                     if (chatData.characterSheet.isEmpty()) {
-                        generate_character(userLanguage, chatData, player, entity);
+                        generate_character(userLanguage, chatData, player, entity, false);
                     }
                 }
             });
@@ -195,7 +195,7 @@ public class ServerPackets {
                 if (entity != null) {
                     EntityChatData chatData = ChatDataManager.getServerInstance().getOrCreateChatData(entity.getStringUUID());
                     if (chatData.characterSheet.isEmpty()) {
-                        generate_character(userLanguage, chatData, player, entity);
+                        generate_character(userLanguage, chatData, player, entity, false);
                     } else {
                         generate_chat(userLanguage, chatData, player, entity, message, false);
                     }
@@ -253,8 +253,10 @@ public class ServerPackets {
         });
         ServerWorldEvents.UNLOAD.register((server, world) -> {
             String world_name = world.dimension().location().getPath();
-            if (world_name == "overworld") {
-                ChatDataManager.getServerInstance().saveChatData(server);
+            if (world_name.equals("overworld")) {
+                ChatDataManager manager = ChatDataManager.getServerInstance();
+                manager.saveChatData(server);
+                manager.clearData();
                 serverInstance = null;
 
                 // Shutdown auto scheduler
@@ -300,7 +302,12 @@ public class ServerPackets {
         }
     }
 
-    public static void generate_character(String userLanguage, EntityChatData chatData, ServerPlayer player, Mob entity) {
+    public static void generate_character(String userLanguage, EntityChatData chatData, ServerPlayer player, Mob entity, boolean is_auto_message) {
+        ConfigurationHandler.Config config = new ConfigurationHandler(serverInstance).loadConfig();
+        ChatDataManager manager = ChatDataManager.getServerInstance();
+        if (!manager.handleAutoResponse(chatData, player, is_auto_message, config)) {
+            return;
+        }
         // Set talk to player goal (prevent entity from walking off)
         TalkPlayerGoal talkGoal = new TalkPlayerGoal(player, entity, 3.5F);
         EntityBehaviorManager.addGoal(entity, talkGoal, GoalPriority.TALK_PLAYER);
@@ -328,9 +335,9 @@ public class ServerPackets {
         userMessageBuilder.append("They speak in '").append(userLanguage).append("' with a ").append(randomSpeakingStyle).append(" style.");
 
         // Generate new character
-        chatData.generateCharacter(userLanguage, player, userMessageBuilder.toString(), false);
+        chatData.generateCharacter(userLanguage, player, userMessageBuilder.toString(), is_auto_message);
 
-// Populate inventory with some simple starter items if empty
+        // Populate inventory with some simple starter items if empty
         if (entity instanceof ChatInventory chatInv) {
             Container inv = chatInv.creaturechat$getInventory();
 
@@ -388,6 +395,12 @@ public class ServerPackets {
     }
 
     public static void generate_chat(String userLanguage, EntityChatData chatData, ServerPlayer player, Mob entity, String message, boolean is_auto_message) {
+        ConfigurationHandler.Config config = new ConfigurationHandler(serverInstance).loadConfig();
+        ChatDataManager manager = ChatDataManager.getServerInstance();
+        if (!manager.handleAutoResponse(chatData, player, is_auto_message, config)) {
+            return;
+        }
+
         // Set talk to player goal (prevent entity from walking off)
         TalkPlayerGoal talkGoal = new TalkPlayerGoal(player, entity, 3.5F);
         EntityBehaviorManager.addGoal(entity, talkGoal, GoalPriority.TALK_PLAYER);

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -36,7 +36,7 @@
 	"accessWidener": "creaturechat.accesswidener",
 	"depends": {
 		"fabricloader": ">=0.14.22",
-		"minecraft": ">=1.20",
+		"minecraft": "~1.21.7",
 		"java": ">=17",
 		"fabric-api": "*"
 	}

--- a/src/vs/v1_20_5/main/java/com/owlmaddie/mixin/MixinMobEntity.java
+++ b/src/vs/v1_20_5/main/java/com/owlmaddie/mixin/MixinMobEntity.java
@@ -223,7 +223,7 @@ public class MixinMobEntity implements ChatInventory, HasCustomInventoryScreen {
                 String giveItemMessage = "<" + serverPlayer.getName().getString() +
                         action_verb + "you " + itemCount + " " + itemName + ">";
 
-                if (!entityData.characterSheet.isEmpty() && entityData.auto_generated < chatDataManager.MAX_AUTOGENERATE_RESPONSES) {
+                if (!entityData.characterSheet.isEmpty()) {
                     ServerPackets.generate_chat("N/A", entityData, serverPlayer, thisEntity, giveItemMessage, true);
                 }
 

--- a/src/vs/v1_21_0/main/java/com/owlmaddie/mixin/MixinMobEntity.java
+++ b/src/vs/v1_21_0/main/java/com/owlmaddie/mixin/MixinMobEntity.java
@@ -226,7 +226,7 @@ public class MixinMobEntity implements ChatInventory, HasCustomInventoryScreen {
                 String giveItemMessage = "<" + serverPlayer.getName().getString() +
                         action_verb + "you " + itemCount + " " + itemName + ">";
 
-                if (!entityData.characterSheet.isEmpty() && entityData.auto_generated < chatDataManager.MAX_AUTOGENERATE_RESPONSES) {
+                if (!entityData.characterSheet.isEmpty()) {
                     ServerPackets.generate_chat("N/A", entityData, serverPlayer, thisEntity, giveItemMessage, true);
                 }
 

--- a/src/vs/v1_21_2/main/java/com/owlmaddie/mixin/MixinLivingEntity.java
+++ b/src/vs/v1_21_2/main/java/com/owlmaddie/mixin/MixinLivingEntity.java
@@ -81,8 +81,7 @@ public class MixinLivingEntity {
                     .getServerInstance()
                     .getOrCreateChatData(mob.getStringUUID());
 
-            if (!data.characterSheet.isEmpty()
-                    && data.auto_generated < ChatDataManager.MAX_AUTOGENERATE_RESPONSES) {
+            if (!data.characterSheet.isEmpty()) {
 
                 ItemStack weapon = serverPlayer.getMainHandItem();
                 String weaponName = weapon.isEmpty()

--- a/src/vs/v1_21_5/main/java/com/owlmaddie/mixin/MixinMobEntity.java
+++ b/src/vs/v1_21_5/main/java/com/owlmaddie/mixin/MixinMobEntity.java
@@ -227,7 +227,7 @@ public class MixinMobEntity implements ChatInventory, HasCustomInventoryScreen {
                 String giveItemMessage = "<" + serverPlayer.getName().getString() +
                         action_verb + "you " + itemCount + " " + itemName + ">";
 
-                if (!entityData.characterSheet.isEmpty() && entityData.auto_generated < chatDataManager.MAX_AUTOGENERATE_RESPONSES) {
+                if (!entityData.characterSheet.isEmpty()) {
                     ServerPackets.generate_chat("N/A", entityData, serverPlayer, thisEntity, giveItemMessage, true);
                 }
 

--- a/src/vs/v1_21_6/main/java/com/owlmaddie/mixin/MixinMobEntity.java
+++ b/src/vs/v1_21_6/main/java/com/owlmaddie/mixin/MixinMobEntity.java
@@ -207,7 +207,7 @@ public class MixinMobEntity implements ChatInventory, HasCustomInventoryScreen {
                 String giveItemMessage = "<" + serverPlayer.getName().getString() +
                         action_verb + "you " + itemCount + " " + itemName + ">";
 
-                if (!entityData.characterSheet.isEmpty() && entityData.auto_generated < chatDataManager.MAX_AUTOGENERATE_RESPONSES) {
+                if (!entityData.characterSheet.isEmpty()) {
                     ServerPackets.generate_chat("N/A", entityData, serverPlayer, thisEntity, giveItemMessage, true);
                 }
 


### PR DESCRIPTION
Improved Auto rate-limits for automatic LLM requests (show item, inventory, attack). Automatic cooldowns for both player and entity. Player has 10 auto generated llm requests per minute, Entity has 1 every 4 seconds. This is to prevent mass LLM requests for specific situations (TNT explosions, large scale attacks / wars, etc...).