### PR TITLE
Rename affiliate program to partner program

### DIFF
--- a/TERMS-PARTNERS.md
+++ b/TERMS-PARTNERS.md
@@ -1,15 +1,15 @@
-# Terms of Service for the CreatureChat™ Affiliate Program
+# Terms of Service for the CreatureChat™ Partner Program
 
 ## 1. Introduction
-Welcome to the CreatureChat™ Affiliate Program! CreatureChat™ is a Minecraft mod owned and operated
+Welcome to the CreatureChat™ Partner Program! CreatureChat™ is a Minecraft mod owned and operated
 by owlmaddie, LLC, a Texas-based company. Our mod enhances gameplay by enabling creatures within
-Minecraft to communicate using natural language processing. As a member of our affiliate program,
-you can earn commissions by promoting CreatureChat™ and driving sales through your unique affiliate
+Minecraft to communicate using natural language processing. As a member of our partner program,
+you can earn commissions by promoting CreatureChat™ and driving sales through your unique partner
 link.
 
 Participation in the program is subject to the following terms and conditions ("Terms"). By
 joining, you agree to abide by these Terms. If you do not agree, you may not participate in
-the affiliate program. **CreatureChat™ is not affiliated with or endorsed by Minecraft, Microsoft, or Mojang.**
+the partner program. **CreatureChat™ is not affiliated with or endorsed by Minecraft, Microsoft, or Mojang.**
 
 ---
 
@@ -21,78 +21,78 @@ the affiliate program. **CreatureChat™ is not affiliated with or endorsed by M
   - Austria (AT), Luxembourg (LU), Ukraine (UA), Saudi Arabia (SA), Portugal (PT),
   - Argentina (AR), Sweden (SE), New Zealand (NZ), Spain (ES), Italy (IT), Philippines (PH), Mexico (MX).
 - We reserve the right to update the list of supported countries at any time.
-- Membership in our **Discord server** is required to participate in this program. Joining the program is done through the `/affiliate join` command in the CreatureChat™ Discord server.
-- If you leave or are banned from our Discord server for any reason, you will be automatically removed from the affiliate program, and any unpaid commissions may be forfeited at our discretion.
+- Membership in our **Discord server** is required to participate in this program. Joining the program is done through the `/partner join` command in the CreatureChat™ Discord server.
+- If you leave or are banned from our Discord server for any reason, you will be automatically removed from the partner program, and any unpaid commissions may be forfeited at our discretion.
 
 ---
 
 ## 3. Earning Commissions
-- Affiliates earn **20% commission** on all sales made through their unique affiliate link. We reserve the right to change the commission rate at our discretion at any time.
-- Commissions are tracked via cookies. Cookies expire after **30 days**, and the last affiliate link clicked will receive the entire commission. For example:
-  - If a customer clicks Affiliate A's link and later clicks Affiliate B's link, then makes a purchase, Affiliate B receives the entire commission.
+- Partners earn **20% commission** on all sales made through their unique partner link. We reserve the right to change the commission rate at our discretion at any time.
+- Commissions are tracked via cookies. Cookies expire after **30 days**, and the last partner link clicked will receive the entire commission. For example:
+  - If a customer clicks Partner A's link and later clicks Partner B's link, then makes a purchase, Partner B receives the entire commission.
 - Self-purchases are not eligible for commissions and are actively tracked.
 - Fraudulent activities, such as spam, bots, cookie injection/manipulation, or self-purchases, may result in forfeiture of commissions and immediate termination from the program.
 - **Commission Calculation & Currency:**
   - Commissions are calculated based on the **USD-equivalent value** of purchases, regardless of the original transaction currency.
   - This ensures consistency in earnings, but commissions themselves have no cash value until redeemed.
-- If an affiliate violates these Terms, we reserve the right to retroactively adjust or revoke commissions at our discretion.
+- If a partner violates these Terms, we reserve the right to retroactively adjust or revoke commissions at our discretion.
 
 ---
 
 ## 4. Redeeming Commissions
 - **Viewing Earnings & Redemption:**
-  - Affiliates can view their statistics, including *clicks, checkouts, samples, purchases, refunds, chargebacks, self-purchases, and earned* commissions, by using the `/affiliate balance` command in the CreatureChat™ Discord server.
-  - Affiliates can initiate a redemption request using the `/affiliate redeem` command in the CreatureChat™ Discord server to withdraw earnings in either tokens or PayPal (USD).
+  - Partners can view their statistics, including *clicks, checkouts, samples, purchases, refunds, chargebacks, self-purchases, and earned* commissions, by using the `/partner balance` command in the CreatureChat™ Discord server.
+  - Partners can initiate a redemption request using the `/partner redeem` command in the CreatureChat™ Discord server to withdraw earnings in either tokens or PayPal (USD).
 
 - **Minimum Redemption Thresholds:**
   - **30 Days:** Commissions must accumulate for a minimum of 30 days before redeeming. 
   - **Tokens:** $5+ commission balance. Tokens are paid immediately upon redemption.
-  - **PayPal:** $50+ commission balance. PayPal (USD) redemptions require verification of affiliate activity, including *clicks, purchases, refunds, self-purchases, and chargebacks*.
+  - **PayPal:** $50+ commission balance. PayPal (USD) redemptions require verification of partner activity, including *clicks, purchases, refunds, self-purchases, and chargebacks*.
     - Payments are processed within 3 to 5 business days after approval.
-    - All PayPal redemptions are processed exclusively in USD, regardless of the affiliate’s local currency.
+    - All PayPal redemptions are processed exclusively in USD, regardless of the partner’s local currency.
 
-- **Chargebacks & Unresponsive Affiliates:**
+- **Chargebacks & Unresponsive Partners:**
   - Chargebacks, self-purchases, and refunds will reduce your commission balance.
   - Excessive chargebacks, self-purchases, or refunds may lead to removal from the program and forfeiture of unpaid commissions.
-  - If an affiliate becomes unresponsive for **6 months or longer**, any unpaid commissions may be forfeited at our discretion.
+  - If a partner becomes unresponsive for **6 months or longer**, any unpaid commissions may be forfeited at our discretion.
 
 ---
 
 ## 5. Program Rules
 To maintain fairness and integrity:
-- Affiliates must not:
+- Partners must not:
   - Engage in fraudulent activities, including but not limited to fake purchases, spam, and misleading promotions.
   - Manipulate cookies, use cookie stuffing, or employ automated means to generate traffic.
   - Misrepresent CreatureChat™ or its services in a deceptive or misleading manner.
   - Use paid advertising (e.g., Google Ads, Facebook Ads) to bid on the "CreatureChat™" brand name or related trademarks.
-- Affiliates are expected to follow applicable laws and ethical guidelines in their promotional activities.
-- Affiliates may be removed from the program at our discretion if their activities are deemed harmful, fraudulent, or abusive.
+- Partners are expected to follow applicable laws and ethical guidelines in their promotional activities.
+- Partners may be removed from the program at our discretion if their activities are deemed harmful, fraudulent, or abusive.
 
 ---
 
 ## 6. Privacy and Data Use
-- Cookies are used to track affiliate activity, including *clicks, checkouts, samples, and purchases*.
+- Cookies are used to track partner activity, including *clicks, checkouts, samples, and purchases*.
 - Your personal data is processed in accordance with our [Privacy Policy](PRIVACY.md). We respect your privacy and only use your data for legitimate program operations.
 
 ---
 
 ## 7. Termination
-- Affiliates may leave the program at any time by using the `/affiliate leave` command in the CreatureChat™ Discord server.
+- Partners may leave the program at any time by using the `/partner leave` command in the CreatureChat™ Discord server.
 - We reserve the right to terminate your participation at any time for violations of these Terms or other actions deemed harmful to the program.
 - Upon termination, any unpaid commissions may be forfeited at our discretion, especially in cases of fraud, abuse, or policy violations.
-- Affiliates who are terminated for violations may not reapply unless explicitly permitted by CreatureChat™.
+- Partners who are terminated for violations may not reapply unless explicitly permitted by CreatureChat™.
 
 ---
 
 ## 8. Limitation of Liability
 CreatureChat™, owlmaddie, LLC, and its affiliates are not liable for indirect, incidental, special, punitive, or consequential damages
-arising from your participation in the affiliate program. Participation is at your own risk.
+arising from your participation in the partner program. Participation is at your own risk.
 
 ---
 
 ## 9. Governing Law & Dispute Resolution
 - These Terms are governed by and construed in accordance with the laws of the State of Texas, United States, without regard to conflict of law principles.
-- Any disputes arising out of or related to the affiliate program shall be resolved through **binding arbitration** administered by the **American Arbitration Association (AAA)** under its **Commercial Arbitration Rules**.
+- Any disputes arising out of or related to the partner program shall be resolved through **binding arbitration** administered by the **American Arbitration Association (AAA)** under its **Commercial Arbitration Rules**.
 - The arbitration shall take place in **Texas**, and the decision of the arbitrator shall be final and binding on all parties.
 
 ---
@@ -103,4 +103,4 @@ We reserve the right to update these Terms at any time. Updates take effect imme
 ---
 
 ## 11. Contact Us
-For questions about these Terms or the affiliate program, please contact us at [affiliate@owlmaddie.com](mailto:affiliate@owlmaddie.com).
+For questions about these Terms or the partner program, please contact us at [partner@owlmaddie.com](mailto:partner@owlmaddie.com).


### PR DESCRIPTION
## Summary
- rename affiliate program to partner program
- update partner commands and contact email